### PR TITLE
Reverting hard-coded github.com/caddy-dns/cloudflare version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM caddy:2.11.2-builder AS builder
 
 RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare@v0.2.4
+    --with github.com/caddy-dns/cloudflare
 
 FROM caddy:2.11.2
 


### PR DESCRIPTION
Reverts #52 now that @latest of github.com/caddy-dns/cloudflare pulls v0.2.4 which includes the needed API key fix:

```
❯ docker build . --progress=plain --no-cache
#0 building with "orbstack" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 209B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/caddy:2.11.2
#2 ...

#3 [internal] load metadata for docker.io/library/caddy:2.11.2-builder
#3 DONE 0.2s

#2 [internal] load metadata for docker.io/library/caddy:2.11.2
#2 DONE 0.2s

#4 [internal] load .dockerignore
#4 transferring context: 2B done
#4 DONE 0.0s

#5 [builder 1/2] FROM docker.io/library/caddy:2.11.2-builder@sha256:c54715e63a99f6bc427f6733749b71dd48fc036f9c4fcda10aa29fb278518ee0
#5 CACHED

#6 [stage-1 1/2] FROM docker.io/library/caddy:2.11.2@sha256:1e40b251ca9639ead7b5cd2cedcc8765adfbabb99450fe23f130eefabf50f4bc
#6 CACHED

#7 [builder 2/2] RUN xcaddy build     --with github.com/caddy-dns/cloudflare
#7 0.104 2026/04/09 12:49:30 [INFO] absolute output file path: /usr/bin/caddy
#7 0.104 2026/04/09 12:49:30 [INFO] Temporary folder: /tmp/buildenv_2026-04-09-1249.970090357
#7 0.104 2026/04/09 12:49:30 [INFO] Writing main module: /tmp/buildenv_2026-04-09-1249.970090357/main.go
#7 0.104 package main
#7 0.104 
#7 0.104 import (
#7 0.104        caddycmd "github.com/caddyserver/caddy/v2/cmd"
#7 0.104 
#7 0.104        // plug in Caddy modules here
#7 0.104        _ "github.com/caddyserver/caddy/v2/modules/standard"
#7 0.104        _ "github.com/caddy-dns/cloudflare"
#7 0.104 )
#7 0.104 
#7 0.104 func main() {
#7 0.104        caddycmd.Main()
#7 0.104 }
#7 0.104 2026/04/09 12:49:30 [INFO] Initializing Go module
#7 0.104 2026/04/09 12:49:30 [INFO] exec (timeout=0s): /usr/local/go/bin/go mod init caddy 
#7 0.112 go: creating new go.mod: module caddy
#7 0.112 go: to add module requirements and sums:
#7 0.112        go mod tidy
#7 0.113 2026/04/09 12:49:30 [INFO] Pinning versions
#7 0.113 2026/04/09 12:49:30 [INFO] exec (timeout=0s): /usr/local/go/bin/go get -v github.com/caddyserver/caddy/v2@v2.11.2 
#7 0.276 go: downloading github.com/caddyserver/caddy/v2 v2.11.2
#7 1.133 go: downloading github.com/caddyserver/certmagic v0.25.2
#7 1.133 go: downloading github.com/cespare/xxhash/v2 v2.3.0
#7 1.134 go: downloading github.com/google/uuid v1.6.0
#7 1.134 go: downloading github.com/prometheus/client_golang v1.23.2
#7 1.135 go: downloading github.com/quic-go/quic-go v0.59.0
#7 1.137 go: downloading go.uber.org/zap v1.27.1
#7 1.137 go: downloading go.uber.org/zap/exp v0.3.0
#7 1.140 go: downloading golang.org/x/sys v0.41.0
#7 1.141 go: downloading golang.org/x/term v0.40.0
#7 1.385 go: downloading github.com/cespare/xxhash v1.1.0
#7 1.397 go: downloading golang.org/x/time v0.14.0
#7 1.487 go: downloading github.com/caddyserver/zerossl v0.1.5
#7 1.487 go: downloading github.com/klauspost/cpuid/v2 v2.3.0
#7 1.487 go: downloading github.com/libdns/libdns v1.1.1
#7 1.487 go: downloading github.com/mholt/acmez/v3 v3.1.6
#7 1.495 go: downloading github.com/miekg/dns v1.1.72
#7 1.495 go: downloading github.com/zeebo/blake3 v0.2.4
#7 1.495 go: downloading golang.org/x/net v0.51.0
#7 1.495 go: downloading golang.org/x/crypto v0.48.0
#7 1.509 go: downloading go.uber.org/multierr v1.11.0
#7 1.540 go: downloading github.com/beorn7/perks v1.0.1
#7 1.540 go: downloading github.com/prometheus/client_model v0.6.2
#7 1.639 go: downloading github.com/prometheus/common v0.67.5
#7 1.700 go: downloading github.com/prometheus/procfs v0.19.2
#7 1.700 go: downloading google.golang.org/protobuf v1.36.11
#7 1.700 go: downloading github.com/quic-go/qpack v0.6.0
#7 1.819 go: downloading golang.org/x/tools v0.42.0
#7 1.819 go: downloading github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
#7 1.849 go: downloading go.yaml.in/yaml/v2 v2.4.3
#7 1.849 go: downloading golang.org/x/text v0.34.0
#7 2.247 go: downloading golang.org/x/sync v0.19.0
#7 2.247 go: downloading golang.org/x/mod v0.33.0
#7 3.229 go: added github.com/beorn7/perks v1.0.1
#7 3.229 go: added github.com/caddyserver/caddy/v2 v2.11.2
#7 3.229 go: added github.com/caddyserver/certmagic v0.25.2
#7 3.229 go: added github.com/caddyserver/zerossl v0.1.5
#7 3.229 go: added github.com/cespare/xxhash/v2 v2.3.0
#7 3.229 go: added github.com/google/uuid v1.6.0
#7 3.229 go: added github.com/klauspost/cpuid/v2 v2.3.0
#7 3.229 go: added github.com/libdns/libdns v1.1.1
#7 3.229 go: added github.com/mholt/acmez/v3 v3.1.6
#7 3.229 go: added github.com/miekg/dns v1.1.72
#7 3.229 go: added github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
#7 3.229 go: added github.com/prometheus/client_golang v1.23.2
#7 3.229 go: added github.com/prometheus/client_model v0.6.2
#7 3.229 go: added github.com/prometheus/common v0.67.5
#7 3.229 go: added github.com/prometheus/procfs v0.19.2
#7 3.229 go: added github.com/quic-go/qpack v0.6.0
#7 3.229 go: added github.com/quic-go/quic-go v0.59.0
#7 3.229 go: added github.com/zeebo/blake3 v0.2.4
#7 3.229 go: added go.uber.org/multierr v1.11.0
#7 3.229 go: added go.uber.org/zap v1.27.1
#7 3.229 go: added go.uber.org/zap/exp v0.3.0
#7 3.229 go: added go.yaml.in/yaml/v2 v2.4.3
#7 3.229 go: added golang.org/x/crypto v0.48.0
#7 3.229 go: added golang.org/x/mod v0.33.0
#7 3.229 go: added golang.org/x/net v0.51.0
#7 3.229 go: added golang.org/x/sync v0.19.0
#7 3.229 go: added golang.org/x/sys v0.41.0
#7 3.229 go: added golang.org/x/term v0.40.0
#7 3.229 go: added golang.org/x/text v0.34.0
#7 3.229 go: added golang.org/x/time v0.14.0
#7 3.229 go: added golang.org/x/tools v0.42.0
#7 3.229 go: added google.golang.org/protobuf v1.36.11
#7 3.241 2026/04/09 12:49:33 [INFO] exec (timeout=0s): /usr/local/go/bin/go get -v github.com/caddy-dns/cloudflare github.com/caddyserver/caddy/v2@v2.11.2 
#7 3.943 go: downloading github.com/caddy-dns/cloudflare v0.2.4
#7 4.000 go: downloading github.com/libdns/cloudflare v0.2.2
#7 4.420 go: added github.com/caddy-dns/cloudflare v0.2.4
#7 4.420 go: added github.com/libdns/cloudflare v0.2.2
#7 4.431 2026/04/09 12:49:34 [INFO] exec (timeout=0s): /usr/local/go/bin/go get -v  
#7 4.448 go: downloading github.com/go-chi/chi/v5 v5.2.5
#7 4.449 go: downloading github.com/smallstep/certificates v0.30.0-rc3
#7 4.450 go: downloading github.com/KimMachineGun/automemlimit v0.7.5
#7 4.451 go: downloading github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b
#7 4.451 go: downloading github.com/DeRuina/timberjack v1.3.9
#7 4.452 go: downloading github.com/dustin/go-humanize v1.0.1
#7 4.453 go: downloading github.com/spf13/cobra v1.10.2
#7 4.455 go: downloading github.com/cloudflare/circl v1.6.3
#7 5.129 go: downloading github.com/smallstep/truststore v0.13.0
#7 5.194 go: downloading github.com/spf13/pflag v1.0.10
#7 5.194 go: downloading go.step.sm/crypto v0.76.2
#7 5.194 go: downloading github.com/smallstep/nosql v0.7.0
#7 5.195 go: downloading go.uber.org/automaxprocs v1.6.0
#7 5.292 go: downloading github.com/tailscale/tscert v0.0.0-20251216020129-aea342f6d747
#7 5.293 go: downloading golang.org/x/crypto/x509roots/fallback v0.0.0-20260213171211-a408498e5541
#7 5.296 go: downloading github.com/google/cel-go v0.27.0
#7 5.502 go: downloading github.com/klauspost/compress v1.18.4
#7 5.624 go: downloading github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
#7 5.624 go: downloading github.com/inconshreveable/mousetrap v1.1.0
#7 5.624 go: downloading go.yaml.in/yaml/v3 v3.0.4
#7 5.624 go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.7
#7 5.625 go: downloading github.com/coreos/go-oidc/v3 v3.17.0
#7 5.625 go: downloading github.com/google/go-tpm v0.9.8
#7 5.625 go: downloading github.com/pkg/errors v0.9.1
#7 5.625 go: downloading github.com/smallstep/go-attestation v0.4.4-0.20241119153605-2306d5b464ca
#7 5.625 go: downloading github.com/fxamacker/cbor/v2 v2.9.0
#7 5.626 go: downloading github.com/pires/go-proxyproto v0.11.0
#7 5.857 go: downloading github.com/smallstep/cli-utils v0.12.2
#7 5.924 go: downloading github.com/smallstep/linkedca v0.25.0
#7 5.924 go: downloading google.golang.org/grpc v1.79.1
#7 5.926 go: downloading github.com/slackhq/nebula v1.10.3
#7 5.926 go: downloading github.com/BurntSushi/toml v1.6.0
#7 5.926 go: downloading github.com/Masterminds/sprig/v3 v3.3.0
#7 5.926 go: downloading github.com/alecthomas/chroma/v2 v2.23.1
#7 5.969 go: downloading github.com/yuin/goldmark v1.7.16
#7 6.262 go: downloading github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
#7 6.313 go: downloading gopkg.in/yaml.v3 v3.0.1
#7 6.335 go: downloading go.opentelemetry.io/contrib/exporters/autoexport v0.65.0
#7 6.335 go: downloading go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0
#7 6.336 go: downloading go.opentelemetry.io/contrib/propagators/autoprop v0.65.0
#7 6.336 go: downloading go.opentelemetry.io/otel v1.40.0
#7 6.336 go: downloading go.opentelemetry.io/otel/sdk v1.40.0
#7 6.546 go: downloading go.opentelemetry.io/otel/trace v1.40.0
#7 6.567 go: downloading howett.net/plist v1.0.0
#7 6.567 go: downloading cel.dev/expr v0.25.1
#7 6.568 go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409
#7 6.568 go: downloading github.com/antlr4-go/antlr/v4 v4.13.1
#7 6.597 go: downloading github.com/go-jose/go-jose/v3 v3.0.4
#7 6.597 go: downloading github.com/ccoveille/go-safecast/v2 v2.0.0
#7 6.772 go: downloading github.com/sirupsen/logrus v1.9.4
#7 6.772 go: downloading github.com/smallstep/pkcs7 v0.2.1
#7 6.772 go: downloading github.com/x448/float16 v0.8.4
#7 6.772 go: downloading github.com/smallstep/scep v0.0.0-20250318231241-a25cabb69492
#7 6.803 go: downloading github.com/russross/blackfriday/v2 v2.1.0
#7 6.803 go: downloading golang.org/x/oauth2 v0.35.0
#7 6.803 go: downloading github.com/go-jose/go-jose/v4 v4.1.3
#7 6.803 go: downloading github.com/rs/xid v1.6.0
#7 6.834 go: downloading filippo.io/edwards25519 v1.2.0
#7 6.838 go: downloading google.golang.org/api v0.266.0
#7 6.866 go: downloading github.com/google/go-tspi v0.3.0
#7 7.042 go: downloading github.com/urfave/cli v1.22.17
#7 7.042 go: downloading dario.cat/mergo v1.0.2
#7 7.042 go: downloading github.com/Masterminds/goutils v1.1.1
#7 7.042 go: downloading github.com/huandu/xstrings v1.5.0
#7 7.042 go: downloading github.com/Masterminds/semver/v3 v3.4.0
#7 7.044 go: downloading github.com/shopspring/decimal v1.4.0
#7 7.044 go: downloading github.com/mitchellh/copystructure v1.2.0
#7 7.044 go: downloading github.com/spf13/cast v1.7.0
#7 7.054 go: downloading github.com/chzyer/readline v1.5.1
#7 7.055 go: downloading google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1
#7 7.055 go: downloading github.com/manifoldco/promptui v0.9.0
#7 7.055 go: downloading go.opentelemetry.io/contrib/propagators/aws v1.40.0
#7 7.056 go: downloading go.opentelemetry.io/contrib/propagators/b3 v1.40.0
#7 7.245 go: downloading go.opentelemetry.io/contrib/propagators/jaeger v1.40.0
#7 7.245 go: downloading go.opentelemetry.io/contrib/propagators/ot v1.40.0
#7 7.246 go: downloading github.com/felixge/httpsnoop v1.0.4
#7 7.271 go: downloading go.opentelemetry.io/otel/metric v1.40.0
#7 7.272 go: downloading go.opentelemetry.io/contrib/bridges/prometheus v0.65.0
#7 7.272 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
#7 7.272 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.16.0
#7 7.278 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0
#7 7.278 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.40.0
#7 7.278 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0
#7 7.312 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0
#7 7.316 go: downloading go.opentelemetry.io/otel/exporters/prometheus v0.62.0
#7 7.320 go: downloading go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.16.0
#7 7.439 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0
#7 7.439 go: downloading go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.40.0
#7 7.439 go: downloading go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.40.0
#7 7.440 go: downloading go.opentelemetry.io/otel/sdk/log v0.16.0
#7 7.440 go: downloading go.opentelemetry.io/otel/sdk/metric v1.40.0
#7 7.496 go: downloading github.com/dgraph-io/badger v1.6.2
#7 7.508 go: downloading github.com/dgraph-io/badger/v2 v2.2007.4
#7 7.530 go: downloading go.etcd.io/bbolt v1.3.10
#7 7.530 go: downloading github.com/go-sql-driver/mysql v1.8.1
#7 7.609 go: downloading github.com/jackc/pgx/v5 v5.6.0
#7 7.611 go: downloading github.com/mitchellh/go-ps v1.0.0
#7 7.611 go: downloading github.com/tailscale/go-winio v0.0.0-20231025203758-c4f33415bf55
#7 7.621 go: downloading golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
#7 7.630 go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20
#7 7.631 go: downloading github.com/google/certificate-transparency-go v1.1.8-0.20240110162603-74a5dd331745
#7 7.811 go: downloading github.com/dlclark/regexp2 v1.11.5
#7 7.811 go: downloading github.com/mitchellh/reflectwalk v1.0.2
#7 7.811 go: downloading filippo.io/bigmod v0.1.0
#7 7.811 go: downloading github.com/go-logr/logr v1.4.3
#7 7.811 go: downloading go.opentelemetry.io/proto/otlp v1.9.0
#7 7.838 go: downloading github.com/prometheus/otlptranslator v1.0.0
#7 7.838 go: downloading go.opentelemetry.io/otel/log v0.16.0
#7 7.984 go: downloading github.com/go-logr/stdr v1.2.2
#7 7.985 go: downloading go.opentelemetry.io/auto/sdk v1.2.1
#7 7.985 go: downloading github.com/dgraph-io/ristretto v0.2.0
#7 8.019 go: downloading github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
#7 8.019 go: downloading github.com/golang/protobuf v1.5.4
#7 8.019 go: downloading github.com/cenkalti/backoff/v5 v5.0.3
#7 8.020 go: downloading github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
#7 8.020 go: downloading github.com/golang/snappy v0.0.4
#7 8.020 go: downloading github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7
#7 8.052 go: downloading github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96
#7 8.085 go: downloading github.com/jackc/pgpassfile v1.0.0
#7 8.203 go: downloading github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a
#7 8.203 go: downloading github.com/jackc/puddle/v2 v2.2.1
#7 8.203 go: downloading github.com/shurcooL/sanitized_anchor_name v1.0.0
#7 8.203 go: downloading github.com/mattn/go-colorable v0.1.14
#7 8.481 go: downloading github.com/mattn/go-isatty v0.0.20
#7 9.223 go: downloading github.com/googleapis/enterprise-certificate-proxy v0.3.11
#7 9.223 go: downloading cloud.google.com/go/auth v0.18.1
#7 9.223 go: downloading github.com/google/s2a-go v0.1.9
#7 9.223 go: downloading github.com/googleapis/gax-go/v2 v2.17.0
#7 9.223 go: downloading cloud.google.com/go/auth/oauth2adapt v0.2.8
#7 9.223 go: downloading cloud.google.com/go/compute/metadata v0.9.0
#7 13.54 2026/04/09 12:49:43 [INFO] Build environment ready
#7 13.54 2026/04/09 12:49:43 [INFO] Building Caddy
#7 13.54 2026/04/09 12:49:43 [INFO] exec (timeout=0s): /usr/local/go/bin/go mod tidy -e 
#7 13.60 go: downloading github.com/stretchr/testify v1.11.1
#7 13.60 go: downloading go.uber.org/goleak v1.3.0
#7 13.60 go: downloading github.com/google/go-cmp v0.7.0
#7 13.60 go: downloading github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262
#7 13.60 go: downloading github.com/fortytw2/leaktest v1.3.0
#7 13.60 go: downloading code.pfad.fr/check v1.1.0
#7 13.60 go: downloading github.com/letsencrypt/pebble/v2 v2.10.0
#7 13.60 go: downloading go.uber.org/mock v0.6.0
#7 13.60 go: downloading github.com/zeebo/assert v1.1.0
#7 13.60 go: downloading github.com/kylelemons/godebug v1.1.0
#7 14.25 go: downloading github.com/google/go-tpm-tools v0.4.7
#7 14.25 go: downloading gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
#7 14.25 go: downloading github.com/prashantv/gostub v1.1.0
#7 14.25 go: downloading github.com/peterbourgon/diskv/v3 v3.0.1
#7 14.25 go: downloading github.com/schollz/jsonstore v1.1.0
#7 14.25 go: downloading github.com/alecthomas/assert/v2 v2.11.0
#7 14.26 go: downloading github.com/letsencrypt/challtestsrv v1.4.2
#7 14.26 go: downloading github.com/chzyer/test v1.0.0
#7 14.28 go: downloading github.com/aws/aws-sdk-go-v2/config v1.32.7
#7 14.28 go: downloading github.com/aws/aws-sdk-go-v2/service/kms v1.49.5
#7 14.28 go: downloading cloud.google.com/go/kms v1.25.0
#7 14.29 go: downloading github.com/alecthomas/repr v0.5.2
#7 14.37 go: downloading github.com/frankban/quicktest v1.14.6
#7 14.40 go: downloading go.opentelemetry.io/otel/sdk/log/logtest v0.16.0
#7 14.40 go: downloading github.com/davecgh/go-spew v1.1.1
#7 14.40 go: downloading github.com/pmezard/go-difflib v1.0.0
#7 14.43 go: downloading github.com/chzyer/logex v1.2.1
#7 14.44 go: downloading github.com/kr/pretty v0.3.1
#7 14.44 go: downloading github.com/google/btree v1.1.2
#7 14.47 go: downloading github.com/zeebo/pcg v1.0.1
#7 14.50 go: downloading github.com/aws/aws-sdk-go-v2 v1.41.1
#7 14.50 go: downloading cloud.google.com/go v0.123.0
#7 14.52 go: downloading google.golang.org/genproto v0.0.0-20260128011058-8636f8732409
#7 14.53 go: downloading github.com/OneOfOne/xxhash v1.2.2
#7 14.56 go: downloading github.com/spaolacci/murmur3 v1.1.0
#7 14.56 go: downloading gonum.org/v1/gonum v0.16.0
#7 14.56 go: downloading github.com/hexops/gotextdiff v1.0.3
#7 14.74 go: downloading github.com/rogpeppe/go-internal v1.14.1
#7 14.74 go: downloading github.com/kr/text v0.2.0
#7 14.76 go: downloading github.com/aws/smithy-go v1.24.0
#7 14.81 go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17
#7 15.00 go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.19.7
#7 15.00 go: downloading github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4
#7 15.00 go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17
#7 15.00 go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.30.9
#7 15.00 go: downloading github.com/aws/aws-sdk-go-v2/service/signin v1.0.5
#7 15.00 go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13
#7 15.10 go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
#7 15.10 go: downloading cloud.google.com/go/iam v1.5.3
#7 15.20 go: downloading cloud.google.com/go/longrunning v0.8.0
#7 15.20 go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17
#7 15.20 go: downloading go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
#7 15.26 go: downloading github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4
#7 15.26 go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17
#7 15.53 2026/04/09 12:49:45 [INFO] exec (timeout=0s): /usr/local/go/bin/go build -o /usr/bin/caddy -ldflags -w -s -trimpath -tags nobadger,nomysql,nopgx 
#7 24.91 2026/04/09 12:49:54 [INFO] Build complete: ./caddy
#7 24.91 2026/04/09 12:49:54 [INFO] Skipping cleanup as requested; leaving folder intact: /tmp/buildenv_2026-04-09-1249.970090357
#7 24.91 2026/04/09 12:49:54 [INFO] Setting capabilities (requires admin privileges): [setcap cap_net_bind_service=+ep ./caddy]
#7 24.91 
#7 24.91 ././caddy version
#7 24.92 v2.11.2 h1:iOlpsSiSKqEW+SIXrcZsZ/NO74SzB/ycqqvAIEfIm64=
#7 DONE 25.0s

#8 [stage-1 2/2] COPY --from=builder /usr/bin/caddy /usr/bin/caddy
#8 DONE 0.0s

#9 exporting to image
#9 exporting layers 0.1s done
#9 writing image sha256:5e63d79cc75ecd10a73a80cd59d09cc1d80bab2c713bd6cc1e3ac4bf565f5396 done
#9 DONE 0.1s
```